### PR TITLE
Add Codex CLI support: template, CLI init, and release assets

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -93,10 +93,35 @@ jobs:
           echo "⚠️ agent_templates/claude folder not found"
         fi
         
+        # Helper: generate commands from templates/commands for specific agent
+        generate_commands() {
+          local ext=$1
+          local arg_format=$2
+          local output_dir=$3
+
+          mkdir -p "$output_dir"
+
+          for template in templates/commands/*.md; do
+            if [[ -f "$template" ]]; then
+              name=$(basename "$template" .md)
+              description=$(awk '/^description:/ {gsub(/^description: *"?/, ""); gsub(/"$/, ""); print; exit}' "$template" | tr -d '\r')
+              content=$(awk '/^---$/{if(++count==2) start=1; next} start' "$template" | sed "s/{ARGS}/$arg_format/g")
+
+              # For Codex and Claude we emit plain markdown prompt files
+              {
+                echo "$content"
+              } > "$output_dir/$name.md"
+            fi
+          done
+        }
+
         # Create Codex CLI package
         echo "Creating Codex CLI package..."
         mkdir -p sdd-codex-package
         cp -r sdd-package-base/* sdd-codex-package/
+        # Generate .codex/commands from templates
+        mkdir -p sdd-codex-package/.codex/commands
+        generate_commands "md" "\$ARGUMENTS" "sdd-codex-package/.codex/commands"
         if [ -d "agent_templates/codex" ]; then
           cp -r agent_templates/codex sdd-codex-package/.codex
           # Move CODEX.md to root for easier access if present
@@ -104,12 +129,7 @@ jobs:
             mv sdd-codex-package/.codex/CODEX.md sdd-codex-package/CODEX.md
             echo "✓ Moved CODEX.md to root of Codex package"
           fi
-          # Remove empty .codex folder if it only contained CODEX.md
-          if [ -d "sdd-codex-package/.codex" ] && [ -z "$(find sdd-codex-package/.codex -type f)" ]; then
-            rm -rf sdd-codex-package/.codex
-            echo "✓ Removed empty .codex folder"
-          fi
-          echo "✓ Added Codex CLI commands ($(find agent_templates/codex -type f | wc -l) files)"
+          echo "✓ Added Codex CLI extras from agent_templates/codex ($(find agent_templates/codex -type f | wc -l) files)"
         else
           echo "⚠️ agent_templates/codex folder not found"
         fi

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -93,6 +93,27 @@ jobs:
           echo "⚠️ agent_templates/claude folder not found"
         fi
         
+        # Create Codex CLI package
+        echo "Creating Codex CLI package..."
+        mkdir -p sdd-codex-package
+        cp -r sdd-package-base/* sdd-codex-package/
+        if [ -d "agent_templates/codex" ]; then
+          cp -r agent_templates/codex sdd-codex-package/.codex
+          # Move CODEX.md to root for easier access if present
+          if [ -f "sdd-codex-package/.codex/CODEX.md" ]; then
+            mv sdd-codex-package/.codex/CODEX.md sdd-codex-package/CODEX.md
+            echo "✓ Moved CODEX.md to root of Codex package"
+          fi
+          # Remove empty .codex folder if it only contained CODEX.md
+          if [ -d "sdd-codex-package/.codex" ] && [ -z "$(find sdd-codex-package/.codex -type f)" ]; then
+            rm -rf sdd-codex-package/.codex
+            echo "✓ Removed empty .codex folder"
+          fi
+          echo "✓ Added Codex CLI commands ($(find agent_templates/codex -type f | wc -l) files)"
+        else
+          echo "⚠️ agent_templates/codex folder not found"
+        fi
+
         # Create Gemini CLI package
         echo "Creating Gemini CLI package..."
         mkdir -p sdd-gemini-package
@@ -130,6 +151,8 @@ jobs:
         echo "Creating archive files..."
         cd sdd-claude-package && zip -r ../spec-kit-template-claude-${{ steps.version.outputs.new_version }}.zip . && cd ..
         
+        cd sdd-codex-package && zip -r ../spec-kit-template-codex-${{ steps.version.outputs.new_version }}.zip . && cd ..
+
         cd sdd-gemini-package && zip -r ../spec-kit-template-gemini-${{ steps.version.outputs.new_version }}.zip . && cd ..
         
         cd sdd-copilot-package && zip -r ../spec-kit-template-copilot-${{ steps.version.outputs.new_version }}.zip . && cd ..
@@ -137,6 +160,7 @@ jobs:
         echo ""
         echo "📦 Packages created:"
         echo "Claude: $(ls -lh spec-kit-template-claude-*.zip | awk '{print $5}')"
+        echo "Codex: $(ls -lh spec-kit-template-codex-*.zip | awk '{print $5}')"
         echo "Gemini: $(ls -lh spec-kit-template-gemini-*.zip | awk '{print $5}')"
         echo "Copilot: $(ls -lh spec-kit-template-copilot-*.zip | awk '{print $5}')"
         echo "Copilot: $(ls -lh sdd-template-copilot-*.zip | awk '{print $5}')"
@@ -156,6 +180,7 @@ jobs:
         
         # Count files in each directory
         CLAUDE_COUNT=$(find agent_templates/claude -type f 2>/dev/null | wc -l || echo "0")
+        CODEX_COUNT=$(find agent_templates/codex -type f 2>/dev/null | wc -l || echo "0")
         GEMINI_COUNT=$(find agent_templates/gemini -type f 2>/dev/null | wc -l || echo "0")
         COPILOT_COUNT=$(find agent_templates/copilot -type f 2>/dev/null | wc -l || echo "0")
         MEMORY_COUNT=$(find memory -type f 2>/dev/null | wc -l || echo "0")
@@ -164,11 +189,12 @@ jobs:
         cat > release_notes.md << EOF
         Template release ${{ steps.version.outputs.new_version }}
         
-        Updated specification-driven development templates for GitHub Copilot, Claude Code, and Gemini CLI.
+        Updated specification-driven development templates for GitHub Copilot, Claude Code, Codex CLI, and Gemini CLI.
         
         Download the template for your preferred AI assistant:
         - spec-kit-template-copilot-${{ steps.version.outputs.new_version }}.zip
         - spec-kit-template-claude-${{ steps.version.outputs.new_version }}.zip
+        - spec-kit-template-codex-${{ steps.version.outputs.new_version }}.zip  
         - spec-kit-template-gemini-${{ steps.version.outputs.new_version }}.zip  
         
         Changes since $LAST_TAG:
@@ -184,6 +210,7 @@ jobs:
         gh release create ${{ steps.version.outputs.new_version }} \
           spec-kit-template-copilot-${{ steps.version.outputs.new_version }}.zip \
           spec-kit-template-claude-${{ steps.version.outputs.new_version }}.zip \
+          spec-kit-template-codex-${{ steps.version.outputs.new_version }}.zip \
           spec-kit-template-gemini-${{ steps.version.outputs.new_version }}.zip \
           --title "Spec Kit Templates - $VERSION_NO_V" \
           --notes-file release_notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,18 @@ jobs:
         mkdir -p sdd-claude-package/.claude/commands
         generate_commands "claude" "md" "\$ARGUMENTS" "sdd-claude-package/.claude/commands"
         echo "Created Claude Code package"
-        
+
+        # Create Codex CLI package
+        mkdir -p sdd-codex-package
+        cp -r sdd-package-base/* sdd-codex-package/
+        mkdir -p sdd-codex-package/.codex/commands
+        generate_commands "codex" "md" "\$ARGUMENTS" "sdd-codex-package/.codex/commands"
+        # If there is a prebuilt CODEX.md, place it in the root for convenience
+        if [ -f "agent_templates/codex/CODEX.md" ]; then
+          cp agent_templates/codex/CODEX.md sdd-codex-package/CODEX.md
+        fi
+        echo "Created Codex CLI package"
+
         # Create Gemini CLI package  
         mkdir -p sdd-gemini-package
         cp -r sdd-package-base/* sdd-gemini-package/
@@ -144,6 +155,8 @@ jobs:
         
         # Create archive files for each package
         cd sdd-claude-package && zip -r ../spec-kit-template-claude-${{ steps.get_tag.outputs.new_version }}.zip . && cd ..
+
+        cd sdd-codex-package && zip -r ../spec-kit-template-codex-${{ steps.get_tag.outputs.new_version }}.zip . && cd ..
         
         cd sdd-gemini-package && zip -r ../spec-kit-template-gemini-${{ steps.get_tag.outputs.new_version }}.zip . && cd ..
         
@@ -152,6 +165,8 @@ jobs:
         # List contents for verification
         echo "Claude package contents:"
         unzip -l spec-kit-template-claude-${{ steps.get_tag.outputs.new_version }}.zip | head -10
+        echo "Codex package contents:"
+        unzip -l spec-kit-template-codex-${{ steps.get_tag.outputs.new_version }}.zip | head -10
         echo "Gemini package contents:"
         unzip -l spec-kit-template-gemini-${{ steps.get_tag.outputs.new_version }}.zip | head -10
         echo "Copilot package contents:"
@@ -179,11 +194,12 @@ jobs:
         cat > release_notes.md << EOF
         Template release ${{ steps.get_tag.outputs.new_version }}
         
-        Updated specification-driven development templates for GitHub Copilot, Claude Code, and Gemini CLI.
+        Updated specification-driven development templates for GitHub Copilot, Claude Code, Codex CLI, and Gemini CLI.
         
         Download the template for your preferred AI assistant:
         - spec-kit-template-copilot-${{ steps.get_tag.outputs.new_version }}.zip
         - spec-kit-template-claude-${{ steps.get_tag.outputs.new_version }}.zip
+        - spec-kit-template-codex-${{ steps.get_tag.outputs.new_version }}.zip
         - spec-kit-template-gemini-${{ steps.get_tag.outputs.new_version }}.zip  
         EOF
         
@@ -200,6 +216,7 @@ jobs:
         gh release create ${{ steps.get_tag.outputs.new_version }} \
           spec-kit-template-copilot-${{ steps.get_tag.outputs.new_version }}.zip \
           spec-kit-template-claude-${{ steps.get_tag.outputs.new_version }}.zip \
+          spec-kit-template-codex-${{ steps.get_tag.outputs.new_version }}.zip \
           spec-kit-template-gemini-${{ steps.get_tag.outputs.new_version }}.zip \
           --title "Spec Kit Templates - $VERSION_NO_V" \
           --notes-file release_notes.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ These are one time installations required to be able to test your changes locall
 1. Install [Python 3.11+](https://www.python.org/downloads/)
 1. Install [uv](https://docs.astral.sh/uv/) for package management
 1. Install [Git](https://git-scm.com/downloads)
-1. Have an AI coding agent available: [Claude Code](https://www.anthropic.com/claude-code), [GitHub Copilot](https://code.visualstudio.com/), or [Gemini CLI](https://github.com/google-gemini/gemini-cli)
+1. Have an AI coding agent available: [Claude Code](https://www.anthropic.com/claude-code), [Codex CLI](https://github.com/openai/codex), [GitHub Copilot](https://code.visualstudio.com/), or [Gemini CLI](https://github.com/google-gemini/gemini-cli)
 
 ## Submitting a pull request
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Our research and experimentation focus on:
 ## 🔧 Prerequisites
 
 - **Linux/macOS** (or WSL2 on Windows)
-- AI coding agent: [Claude Code](https://www.anthropic.com/claude-code), [GitHub Copilot](https://code.visualstudio.com/), or [Gemini CLI](https://github.com/google-gemini/gemini-cli)
+- AI coding agent: [Claude Code](https://www.anthropic.com/claude-code), [Codex CLI](https://github.com/openai/codex), [GitHub Copilot](https://code.visualstudio.com/), or [Gemini CLI](https://github.com/google-gemini/gemini-cli)
 - [uv](https://docs.astral.sh/uv/) for package management
 - [Python 3.11+](https://www.python.org/downloads/)
 - [Git](https://git-scm.com/downloads)
@@ -145,16 +145,19 @@ You will be prompted to select the AI agent you are using. You can also proactiv
 
 ```bash
 specify init <project_name> --ai claude
+specify init <project_name> --ai codex
 specify init <project_name> --ai gemini
 specify init <project_name> --ai copilot
 # Or in current directory:
 specify init --here --ai claude
+specify init --here --ai codex
 ```
 
-The CLI will check if you have Claude Code or Gemini CLI installed. If you do not, or you prefer to get the templates without checking for the right tools, use `--ignore-agent-tools` with your command:
+The CLI will check if you have Claude Code, Codex CLI, or Gemini CLI installed. If you do not, or you prefer to get the templates without checking for the right tools, use `--ignore-agent-tools` with your command:
 
 ```bash
 specify init <project_name> --ai claude --ignore-agent-tools
+specify init <project_name> --ai codex --ignore-agent-tools
 ```
 
 ### **STEP 1:** Bootstrap the project

--- a/README.md
+++ b/README.md
@@ -285,6 +285,40 @@ The output of this step will include a number of implementation detail documents
     └── tasks-template.md
 ```
 
+If you are using Codex CLI, the layout will mirror this, with Codex-specific files and folder names:
+
+```text
+.
+├── CODEX.md
+├── .codex
+│   └── commands
+├── memory
+│   ├── constitution.md
+│   └── constitution_update_checklist.md
+├── scripts
+│   ├── check-task-prerequisites.sh
+│   ├── common.sh
+│   ├── create-new-feature.sh
+│   ├── get-feature-paths.sh
+│   ├── setup-plan.sh
+│   └── update-codex-md.sh
+├── specs
+│   └── 001-create-taskify
+│       ├── contracts
+│       │   ├── api-spec.json
+│       │   └── signalr-spec.md
+│       ├── data-model.md
+│       ├── plan.md
+│       ├── quickstart.md
+│       ├── research.md
+│       └── spec.md
+└── templates
+    ├── CODEX-template.md
+    ├── plan-template.md
+    ├── spec-template.md
+    └── tasks-template.md
+```
+
 Note: Depending on your AI agent, you will see the corresponding agent file (e.g., `CLAUDE.md`, `CODEX.md`, `GEMINI.md`, or `.github/copilot-instructions.md`).
 
 Check the `research.md` document to ensure that the right tech stack is used, based on your instructions. You can ask Claude Code to refine it if any of the components stand out, or even have it check the locally-installed version of the platform/framework you want to use (e.g., .NET).

--- a/README.md
+++ b/README.md
@@ -319,6 +319,17 @@ If you are using Codex CLI, the layout will mirror this, with Codex-specific fil
     └── tasks-template.md
 ```
 
+### Codex CLI Quickstart
+
+- Install: Codex CLI (see link in prerequisites)
+- Init: `specify init <project_name> --ai codex` or `specify init --here --ai codex`
+- Use commands:
+  - In a Codex session, run `/specify`, `/plan`, `/tasks` to drive the workflow
+  - Or open the prompt files in `.codex/commands/` (e.g., `specify.md`, `plan.md`, `tasks.md`) and run them with your feature/context
+- Keep context in sync:
+  - After `/plan`: run `scripts/update-codex-md.sh` (or `scripts/update-agent-context.sh codex`) to refresh `CODEX.md`
+  - After `/tasks`: run `scripts/update-codex-md.sh` again if the plan changed during task generation
+
 Note: Depending on your AI agent, you will see the corresponding agent file (e.g., `CLAUDE.md`, `CODEX.md`, `GEMINI.md`, or `.github/copilot-instructions.md`).
 
 Check the `research.md` document to ensure that the right tech stack is used, based on your instructions. You can ask Claude Code to refine it if any of the components stand out, or even have it check the locally-installed version of the platform/framework you want to use (e.g., .NET).

--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ At this stage, your project folder contents should resemble the following:
     └── tasks-template.md
 ```
 
+Note: If you’re using Codex, your scripts directory will also include `scripts/update-codex-md.sh`.
+
 ### **STEP 2:** Functional specification clarification
 
 With the baseline specification created, you can go ahead and clarify any of the requirements that were not captured properly within the first shot attempt. For example, you could use a prompt like this within the same Claude Code session:
@@ -282,6 +284,8 @@ The output of this step will include a number of implementation detail documents
     ├── spec-template.md
     └── tasks-template.md
 ```
+
+Note: Depending on your AI agent, you will see the corresponding agent file (e.g., `CLAUDE.md`, `CODEX.md`, `GEMINI.md`, or `.github/copilot-instructions.md`).
 
 Check the `research.md` document to ensure that the right tech stack is used, based on your instructions. You can ask Claude Code to refine it if any of the components stand out, or even have it check the locally-installed version of the platform/framework you want to use (e.g., .NET).
 

--- a/agent_templates/codex/CODEX.md
+++ b/agent_templates/codex/CODEX.md
@@ -1,0 +1,24 @@
+# [PROJECT NAME] Development Guidelines
+
+Auto-generated from all feature plans. Last updated: [DATE]
+
+## Active Technologies
+[EXTRACTED FROM ALL PLAN.MD FILES]
+
+## Project Structure
+```
+[ACTUAL STRUCTURE FROM PLANS]
+```
+
+## Commands
+[ONLY COMMANDS FOR ACTIVE TECHNOLOGIES]
+
+## Code Style
+[LANGUAGE-SPECIFIC, ONLY FOR LANGUAGES IN USE]
+
+## Recent Changes
+[LAST 3 FEATURES AND WHAT THEY ADDED]
+
+<!-- MANUAL ADDITIONS START -->
+<!-- MANUAL ADDITIONS END -->
+

--- a/memory/constitution_update_checklist.md
+++ b/memory/constitution_update_checklist.md
@@ -11,6 +11,7 @@ When amending the constitution (`/memory/constitution.md`), ensure all dependent
 - [ ] `/.claude/commands/plan.md` - Update if planning process changes
 - [ ] `/.claude/commands/tasks.md` - Update if task generation affected
 - [ ] `/CLAUDE.md` - Update runtime development guidelines
+- [ ] `/CODEX.md` - Update runtime development guidelines
 
 ### Article-specific updates:
 

--- a/memory/constitution_update_checklist.md
+++ b/memory/constitution_update_checklist.md
@@ -10,6 +10,8 @@ When amending the constitution (`/memory/constitution.md`), ensure all dependent
 - [ ] `/templates/tasks-template.md` - Update if new task types needed
 - [ ] `/.claude/commands/plan.md` - Update if planning process changes
 - [ ] `/.claude/commands/tasks.md` - Update if task generation affected
+- [ ] `/.codex/commands/plan.md` - Update if planning process changes
+- [ ] `/.codex/commands/tasks.md` - Update if task generation affected
 - [ ] `/CLAUDE.md` - Update runtime development guidelines
 - [ ] `/CODEX.md` - Update runtime development guidelines
 

--- a/scripts/update-agent-context.sh
+++ b/scripts/update-agent-context.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Incrementally update agent context files based on new feature plan
-# Supports: CLAUDE.md, GEMINI.md, and .github/copilot-instructions.md
+# Supports: CLAUDE.md, CODEX.md, GEMINI.md, and .github/copilot-instructions.md
 # O(1) operation - only reads current context file and new plan.md
 
 set -e
@@ -12,6 +12,7 @@ NEW_PLAN="$FEATURE_DIR/plan.md"
 
 # Determine which agent context files to update
 CLAUDE_FILE="$REPO_ROOT/CLAUDE.md"
+CODEX_FILE="$REPO_ROOT/CODEX.md"
 GEMINI_FILE="$REPO_ROOT/GEMINI.md"
 COPILOT_FILE="$REPO_ROOT/.github/copilot-instructions.md"
 
@@ -191,6 +192,9 @@ case "$AGENT_TYPE" in
     "claude")
         update_agent_file "$CLAUDE_FILE" "Claude Code"
         ;;
+    "codex")
+        update_agent_file "$CODEX_FILE" "Codex CLI"
+        ;;
     "gemini") 
         update_agent_file "$GEMINI_FILE" "Gemini CLI"
         ;;
@@ -200,17 +204,18 @@ case "$AGENT_TYPE" in
     "")
         # Update all existing files
         [ -f "$CLAUDE_FILE" ] && update_agent_file "$CLAUDE_FILE" "Claude Code"
+        [ -f "$CODEX_FILE" ] && update_agent_file "$CODEX_FILE" "Codex CLI" 
         [ -f "$GEMINI_FILE" ] && update_agent_file "$GEMINI_FILE" "Gemini CLI" 
         [ -f "$COPILOT_FILE" ] && update_agent_file "$COPILOT_FILE" "GitHub Copilot"
         
         # If no files exist, create based on current directory or ask user
-        if [ ! -f "$CLAUDE_FILE" ] && [ ! -f "$GEMINI_FILE" ] && [ ! -f "$COPILOT_FILE" ]; then
+        if [ ! -f "$CLAUDE_FILE" ] && [ ! -f "$CODEX_FILE" ] && [ ! -f "$GEMINI_FILE" ] && [ ! -f "$COPILOT_FILE" ]; then
             echo "No agent context files found. Creating Claude Code context file by default."
             update_agent_file "$CLAUDE_FILE" "Claude Code"
         fi
         ;;
     *)
-        echo "ERROR: Unknown agent type '$AGENT_TYPE'. Use: claude, gemini, copilot, or leave empty for all."
+        echo "ERROR: Unknown agent type '$AGENT_TYPE'. Use: claude, codex, gemini, copilot, or leave empty for all."
         exit 1
         ;;
 esac
@@ -227,8 +232,9 @@ if [ ! -z "$NEW_DB" ] && [ "$NEW_DB" != "N/A" ]; then
 fi
 
 echo ""
-echo "Usage: $0 [claude|gemini|copilot]"
+echo "Usage: $0 [claude|codex|gemini|copilot]"
 echo "  - No argument: Update all existing agent context files"
 echo "  - claude: Update only CLAUDE.md"
+echo "  - codex: Update only CODEX.md" 
 echo "  - gemini: Update only GEMINI.md" 
 echo "  - copilot: Update only .github/copilot-instructions.md"

--- a/scripts/update-codex-md.sh
+++ b/scripts/update-codex-md.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Incrementally update CODEX.md based on new feature plan
+# Modeled after the Claude script and update-agent-context.sh
+
+set -e
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+FEATURE_DIR="$REPO_ROOT/specs/$CURRENT_BRANCH"
+NEW_PLAN="$FEATURE_DIR/plan.md"
+TARGET_FILE="$REPO_ROOT/CODEX.md"
+
+if [ ! -f "$NEW_PLAN" ]; then
+    echo "ERROR: No plan.md found at $NEW_PLAN"
+    exit 1
+fi
+
+echo "=== Updating Codex CLI context file for feature $CURRENT_BRANCH ==="
+
+# Extract tech from new plan
+NEW_LANG=$(grep "^**Language/Version**: " "$NEW_PLAN" 2>/dev/null | head -1 | sed 's/^**Language\/Version**: //' | grep -v "NEEDS CLARIFICATION" || echo "")
+NEW_FRAMEWORK=$(grep "^**Primary Dependencies**: " "$NEW_PLAN" 2>/dev/null | head -1 | sed 's/^**Primary Dependencies**: //' | grep -v "NEEDS CLARIFICATION" || echo "")
+NEW_TESTING=$(grep "^**Testing**: " "$NEW_PLAN" 2>/dev/null | head -1 | sed 's/^**Testing**: //' | grep -v "NEEDS CLARIFICATION" || echo "")
+NEW_DB=$(grep "^**Storage**: " "$NEW_PLAN" 2>/dev/null | head -1 | sed 's/^**Storage**: //' | grep -v "N/A" | grep -v "NEEDS CLARIFICATION" || echo "")
+NEW_PROJECT_TYPE=$(grep "^**Project Type**: " "$NEW_PLAN" 2>/dev/null | head -1 | sed 's/^**Project Type**: //' || echo "")
+
+update_agent_file() {
+    local target_file="$1"
+    local agent_name="$2"
+
+    echo "Updating $agent_name context file: $target_file"
+
+    local temp_file=$(mktemp)
+
+    if [ ! -f "$target_file" ]; then
+        echo "Creating new $agent_name context file..."
+        if [ -f "$REPO_ROOT/templates/agent-file-template.md" ]; then
+            cp "$REPO_ROOT/templates/agent-file-template.md" "$temp_file"
+        else
+            echo "ERROR: Template not found at $REPO_ROOT/templates/agent-file-template.md"
+            return 1
+        fi
+
+        sed -i.bak "s/\[PROJECT NAME\]/$(basename $REPO_ROOT)/" "$temp_file"
+        sed -i.bak "s/\[DATE\]/$(date +%Y-%m-%d)/" "$temp_file"
+        sed -i.bak "s/\[EXTRACTED FROM ALL PLAN.MD FILES\]/- $NEW_LANG + $NEW_FRAMEWORK ($CURRENT_BRANCH)/" "$temp_file"
+
+        if [[ "$NEW_PROJECT_TYPE" == *"web"* ]]; then
+            sed -i.bak "s|\[ACTUAL STRUCTURE FROM PLANS\]|backend/\nfrontend/\ntests/|" "$temp_file"
+        else
+            sed -i.bak "s|\[ACTUAL STRUCTURE FROM PLANS\]|src/\ntests/|" "$temp_file"
+        fi
+
+        if [[ "$NEW_LANG" == *"Python"* ]]; then
+            COMMANDS="cd src && pytest && ruff check ."
+        elif [[ "$NEW_LANG" == *"Rust"* ]]; then
+            COMMANDS="cargo test && cargo clippy"
+        elif [[ "$NEW_LANG" == *"JavaScript"* ]] || [[ "$NEW_LANG" == *"TypeScript"* ]]; then
+            COMMANDS="npm test && npm run lint"
+        else
+            COMMANDS="# Add commands for $NEW_LANG"
+        fi
+        sed -i.bak "s|\[ONLY COMMANDS FOR ACTIVE TECHNOLOGIES\]|$COMMANDS|" "$temp_file"
+
+        sed -i.bak "s|\[LANGUAGE-SPECIFIC, ONLY FOR LANGUAGES IN USE\]|$NEW_LANG: Follow standard conventions|" "$temp_file"
+        sed -i.bak "s|\[LAST 3 FEATURES AND WHAT THEY ADDED\]|- $CURRENT_BRANCH: Added $NEW_LANG + $NEW_FRAMEWORK|" "$temp_file"
+
+        rm "$temp_file.bak"
+    else
+        echo "Updating existing $agent_name context file..."
+
+        local manual_start=$(grep -n "<!-- MANUAL ADDITIONS START -->" "$target_file" | cut -d: -f1)
+        local manual_end=$(grep -n "<!-- MANUAL ADDITIONS END -->" "$target_file" | cut -d: -f1)
+        if [ ! -z "$manual_start" ] && [ ! -z "$manual_end" ]; then
+            sed -n "${manual_start},${manual_end}p" "$target_file" > /tmp/manual_additions.txt
+        fi
+
+        python3 - << EOF
+import re
+from datetime import datetime
+
+with open("$target_file", 'r') as f:
+    content = f.read()
+
+tech_section = re.search(r'## Active Technologies\n(.*?)\n\n', content, re.DOTALL)
+if tech_section:
+    existing_tech = tech_section.group(1)
+    new_additions = []
+    if "$NEW_LANG" and "$NEW_LANG" not in existing_tech:
+        new_additions.append(f"- $NEW_LANG + $NEW_FRAMEWORK ($CURRENT_BRANCH)")
+    if "$NEW_DB" and "$NEW_DB" not in existing_tech and "$NEW_DB" != "N/A":
+        new_additions.append(f"- $NEW_DB ($CURRENT_BRANCH)")
+    if new_additions:
+        updated_tech = existing_tech + "\n" + "\n".join(new_additions)
+        content = content.replace(tech_section.group(0), f"## Active Technologies\n{updated_tech}\n\n")
+
+if "$NEW_PROJECT_TYPE" == "web" and "frontend/" not in content:
+    struct_section = re.search(r'## Project Structure\n\`\`\`\n(.*?)\n\`\`\`', content, re.DOTALL)
+    if struct_section:
+        updated_struct = struct_section.group(1) + "\nfrontend/src/      # Web UI"
+        content = re.sub(r'(## Project Structure\n\`\`\`\n).*?(\n\`\`\`)', f'\\1{updated_struct}\\2', content, flags=re.DOTALL)
+
+if "$NEW_LANG" and f"# {NEW_LANG}" not in content:
+    commands_section = re.search(r'## Commands\n\`\`\`bash\n(.*?)\n\`\`\`', content, re.DOTALL)
+    if not commands_section:
+        commands_section = re.search(r'## Commands\n(.*?)\n\n', content, re.DOTALL)
+    if commands_section:
+        new_commands = commands_section.group(1)
+        if "Python" in "$NEW_LANG":
+            new_commands += "\ncd src && pytest && ruff check ."
+        elif "Rust" in "$NEW_LANG":
+            new_commands += "\ncargo test && cargo clippy"
+        elif "JavaScript" in "$NEW_LANG" or "TypeScript" in "$NEW_LANG":
+            new_commands += "\nnpm test && npm run lint"
+        if "```bash" in content:
+            content = re.sub(r'(## Commands\n\`\`\`bash\n).*?(\n\`\`\`)', f'\\1{new_commands}\\2', content, flags=re.DOTALL)
+        else:
+            content = re.sub(r'(## Commands\n).*?(\n\n)', f'\\1{new_commands}\\2', content, flags=re.DOTALL)
+
+changes_section = re.search(r'## Recent Changes\n(.*?)(\n\n|$)', content, re.DOTALL)
+if changes_section:
+    changes = changes_section.group(1).strip().split('\n')
+    changes.insert(0, f"- $CURRENT_BRANCH: Added $NEW_LANG + $NEW_FRAMEWORK")
+    changes = changes[:3]
+    content = re.sub(r'(## Recent Changes\n).*?(\n\n|$)', f'\\1{chr(10).join(changes)}\\2', content, flags=re.DOTALL)
+
+content = re.sub(r'Last updated: \d{4}-\d{2}-\d{2}', f'Last updated: {datetime.now().strftime("%Y-%m-%d")}', content)
+
+with open("$temp_file", 'w') as f:
+    f.write(content)
+EOF
+
+        if [ -f /tmp/manual_additions.txt ]; then
+            sed -i.bak '/<!-- MANUAL ADDITIONS START -->/,/<!-- MANUAL ADDITIONS END -->/d' "$temp_file"
+            cat /tmp/manual_additions.txt >> "$temp_file"
+            rm /tmp/manual_additions.txt "$temp_file.bak"
+        fi
+    fi
+
+    mv "$temp_file" "$target_file"
+    echo "✓ $agent_name context file updated successfully"
+}
+
+update_agent_file "$TARGET_FILE" "Codex CLI"
+
+echo ""
+echo "Summary of changes:"
+if [ ! -z "$NEW_LANG" ]; then
+    echo "- Added language: $NEW_LANG"
+fi
+if [ ! -z "$NEW_FRAMEWORK" ]; then
+    echo "- Added framework: $NEW_FRAMEWORK"
+fi
+if [ ! -z "$NEW_DB" ] && [ "$NEW_DB" != "N/A" ]; then
+    echo "- Added database: $NEW_DB"
+fi
+
+echo ""
+echo "Usage: $0"
+echo "  Updates or creates CODEX.md from the latest plan.md"
+

--- a/templates/CODEX-template.md
+++ b/templates/CODEX-template.md
@@ -1,0 +1,24 @@
+# [PROJECT NAME] Development Guidelines
+
+Auto-generated from all feature plans. Last updated: [DATE]
+
+## Active Technologies
+[EXTRACTED FROM ALL PLAN.MD FILES]
+
+## Project Structure
+```
+[ACTUAL STRUCTURE FROM PLANS]
+```
+
+## Commands
+[ONLY COMMANDS FOR ACTIVE TECHNOLOGIES]
+
+## Code Style
+[LANGUAGE-SPECIFIC, ONLY FOR LANGUAGES IN USE]
+
+## Recent Changes
+[LAST 3 FEATURES AND WHAT THEY ADDED]
+
+<!-- MANUAL ADDITIONS START -->
+<!-- MANUAL ADDITIONS END -->
+

--- a/templates/commands/plan.md
+++ b/templates/commands/plan.md
@@ -39,3 +39,7 @@ Given the implementation details provided as an argument, do this:
 6. Report results with branch name, file paths, and generated artifacts.
 
 Use absolute paths with the repository root for all file operations to avoid path issues.
+
+7. If using Codex:
+   - Run `scripts/update-codex-md.sh` to update or create `CODEX.md` from the new plan
+   - Alternatively, run `scripts/update-agent-context.sh codex` to keep Codex context in sync

--- a/templates/commands/tasks.md
+++ b/templates/commands/tasks.md
@@ -61,3 +61,7 @@ Given the context provided as an argument, do this:
 Context for task generation: {ARGS}
 
 The tasks.md should be immediately executable - each task must be specific enough that an LLM can complete it without additional context.
+
+If using Codex:
+- Run `scripts/update-codex-md.sh` to sync `CODEX.md` after generating tasks
+- Or run `scripts/update-agent-context.sh codex` to update only the Codex context file

--- a/templates/plan-template.md
+++ b/templates/plan-template.md
@@ -16,7 +16,7 @@
    → Update Progress Tracking: Initial Constitution Check
 4. Execute Phase 0 → research.md
    → If NEEDS CLARIFICATION remain: ERROR "Resolve unknowns"
-5. Execute Phase 1 → contracts, data-model.md, quickstart.md, agent-specific template file (e.g., `CLAUDE.md` for Claude Code, `.github/copilot-instructions.md` for GitHub Copilot, or `GEMINI.md` for Gemini CLI).
+5. Execute Phase 1 → contracts, data-model.md, quickstart.md, agent-specific template file (e.g., `CLAUDE.md` for Claude Code, `CODEX.md` for Codex CLI, `.github/copilot-instructions.md` for GitHub Copilot, or `GEMINI.md` for Gemini CLI).
 6. Re-evaluate Constitution Check section
    → If new violations: Refactor design, return to Phase 1
    → Update Progress Tracking: Post-Design Constitution Check
@@ -171,7 +171,8 @@ ios/ or android/
    - Quickstart test = story validation steps
 
 5. **Update agent file incrementally** (O(1) operation):
-   - Run `/scripts/update-agent-context.sh [claude|gemini|copilot]` for your AI assistant
+   - Run `/scripts/update-agent-context.sh [claude|codex|gemini|copilot]` for your AI assistant
+   - Or use the Codex-specific helper `/scripts/update-codex-md.sh` if you prefer
    - If exists: Add only NEW tech from current plan
    - Preserve manual additions between markers
    - Update recent changes (keep last 3)


### PR DESCRIPTION
Summary: Adds Codex CLI as a first-class assistant in Spec Kit with templates, CLI init flow, and release packaging.

CLI: add --ai codex to specify init; detect codex --version; generate CODEX.md; create .codex/commands (from templates or mirror .claude/commands).

Templates: add agent_templates/codex/CODEX.md and templates/CODEX-template.md.

Scripts: add scripts/update-codex-md.sh; extend scripts/update-agent-context.sh for codex.

Docs: update README.md, CONTRIBUTING.md, and plan/task templates to reference Codex commands.

Release: update .github/workflows/{release,manual-release}.yml to publish spec-kit-template-codex-<version>.zip including .codex/commands and CODEX.md.

Usage: specify init --here --ai codex; scripts/update-codex-md.sh or scripts/update-agent-context.sh codex.

Compatibility: non-breaking; keeps Claude, Gemini, and Copilot support intact.